### PR TITLE
feat: Create 'help' command

### DIFF
--- a/example/bosun.dart
+++ b/example/bosun.dart
@@ -23,5 +23,5 @@ class RunCmd extends Command {
 }
 
 void main(List<String> args) {
-  execute(BosunCommand('donker', subcommands: [RunCmd()]), args);
+  execute(BosunCommand('donker', description: 'The donker CLI tool', subcommands: [RunCmd()]), args);
 }

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -34,8 +34,8 @@ abstract class Command {
 }
 
 class BosunCommand extends Command {
-  BosunCommand(String appName, {required List<Command> subcommands})
-      : super(command: appName, subcommands: subcommands);
+  BosunCommand(String appName, {String description = '', required List<Command> subcommands})
+      : super(command: appName, description: description, subcommands: subcommands);
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {

--- a/lib/src/command_parser.dart
+++ b/lib/src/command_parser.dart
@@ -20,16 +20,16 @@ class CommandParser {
       index++;
 
       finalCmd = finalCmd.subcommands!
-          .firstWhere((element) => element.getAllLogicalNames().contains(cmd), orElse: () => _exceptionHandler(finalCmd, cmd));
+          .firstWhere((element) => element.getAllLogicalNames().contains(cmd), orElse: () => _exceptionHandler(command, finalCmd, cmd));
     }
 
     return ProcessableCommand(finalCmd, flags, arguments);
   }
 
-  static Command _exceptionHandler(Command command, String subcommand) {
-    var bosunCommand = BosunCmd(command);
+  static Command _exceptionHandler(Command root, Command context, String subcommand) {
+    var bosunCommand = BosunCmd(root, context);
     // Eventually we will inspect the arguments here to see if we can suggest a command
-    return bosunCommand.subcommands!.firstWhere((element) => element.getAllLogicalNames().contains(subcommand), orElse: () => HelpCmd(command));
+    return bosunCommand.subcommands!.firstWhere((element) => element.getAllLogicalNames().contains(subcommand), orElse: () => HelpCmd(root, context));
   }
 
   static Map<String, dynamic> _getFlags(List<String> args) {

--- a/lib/src/command_parser.dart
+++ b/lib/src/command_parser.dart
@@ -1,5 +1,6 @@
 import 'package:bosun/src/command_executor.dart';
 import 'package:bosun/src/command.dart';
+import 'package:bosun/src/commands.dart';
 
 class CommandParser {
   static ProcessableCommand parse(Command command, List<String> args) {
@@ -19,10 +20,16 @@ class CommandParser {
       index++;
 
       finalCmd = finalCmd.subcommands!
-          .firstWhere((element) => element.getAllLogicalNames().contains(cmd));
+          .firstWhere((element) => element.getAllLogicalNames().contains(cmd), orElse: () => _exceptionHandler(finalCmd, cmd));
     }
 
     return ProcessableCommand(finalCmd, flags, arguments);
+  }
+
+  static Command _exceptionHandler(Command command, String subcommand) {
+    var bosunCommand = BosunCmd(command);
+    // Eventually we will inspect the arguments here to see if we can suggest a command
+    return bosunCommand.subcommands!.firstWhere((element) => element.getAllLogicalNames().contains(subcommand), orElse: () => HelpCmd(command));
   }
 
   static Map<String, dynamic> _getFlags(List<String> args) {

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -1,9 +1,10 @@
 import 'package:bosun/bosun.dart';
 
 class HelpCmd extends Command {
+  final Command root;
   final Command context;
 
-  HelpCmd(this.context)
+  HelpCmd(this.root, this.context)
       : super(
             command: 'help',
             description: 'Displays helpful information about the current project',
@@ -12,11 +13,11 @@ class HelpCmd extends Command {
   @override
   void run(List<String> args, Map<String, dynamic> flags) {
     String commands = '';
-    for (var element in [...context.subcommands!, ...BosunCmd(context).subcommands!]) {
+    for (var element in [...context.subcommands!, ...BosunCmd(root, context).subcommands!]) {
       commands += '  ${element.command}\t${element.description ?? ''}\n';
     }
     print('''
-A command-line utility for Dart CLI development.
+${root.description}
 
 Usage: <command|dart-file> [arguments]
 
@@ -26,19 +27,19 @@ Global options:
 Available commands:
 $commands
 Run "<command|dart-file> help" for more information about a command.
-See https://github.com/PyreStudios/bosun for detailed documentation.
       ''');
   }
 }
 
 class BosunCmd extends Command {
+  final Command root;
   final Command context;
 
-  BosunCmd(this.context)
+  BosunCmd(this.root, this.context)
       : super(
             command: 'bosun',
             description: 'Run a command in a shell',
-            subcommands: [HelpCmd(context)]);
+            subcommands: [HelpCmd(root, context)]);
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -1,0 +1,47 @@
+import 'package:bosun/bosun.dart';
+
+class HelpCmd extends Command {
+  final Command context;
+
+  HelpCmd(this.context)
+      : super(
+            command: 'help',
+            description: 'Displays helpful information about the current project',
+            subcommands: []);
+
+  @override
+  void run(List<String> args, Map<String, dynamic> flags) {
+    String commands = '';
+    for (var element in [...context.subcommands!, ...BosunCmd(context).subcommands!]) {
+      commands += '  ${element.command}\t${element.description ?? ''}\n';
+    }
+    print('''
+A command-line utility for Dart CLI development.
+
+Usage: <command|dart-file> [arguments]
+
+Global options:
+-h, --help                 Print this usage information.
+
+Available commands:
+$commands
+Run "<command|dart-file> help" for more information about a command.
+See https://github.com/PyreStudios/bosun for detailed documentation.
+      ''');
+  }
+}
+
+class BosunCmd extends Command {
+  final Command context;
+
+  BosunCmd(this.context)
+      : super(
+            command: 'bosun',
+            description: 'Run a command in a shell',
+            subcommands: [HelpCmd(context)]);
+
+  @override
+  void run(List<String> args, Map<String, dynamic> flags) {
+    // Intentionally left blank
+  }
+}


### PR DESCRIPTION
Creates a simple 'help' command that will print out commands available given the current context.

Executing 'help' without specifying a known command will show you the top level commands available.

![image](https://user-images.githubusercontent.com/6115456/146488144-8a6a01bd-0451-4498-9cab-fc168e1e7e1b.png)

Executing 'help' after a command will display the available subcommands.

![image](https://user-images.githubusercontent.com/6115456/146488197-75926e90-f7b1-4584-a0fe-2c1504735a34.png)
